### PR TITLE
URL fix for external site toolbar code

### DIFF
--- a/app/_config/toolbar.yml
+++ b/app/_config/toolbar.yml
@@ -21,7 +21,7 @@ Only:
   environment: test
 ---
 GlobalNav:
-  hostname: '//sssites-ssorg-uat.sites.silverstripe.com/'
+  hostname: '//www.silverstripe.org/'
   css_path: '/themes/ssv3/css/toolbar.min.css'
   use_localhost: false
 ---


### PR DESCRIPTION
URL now points to live site to get toolbar without having to access uat and being blocked by our internal firewall