### PR TITLE
Make the toolbar reference the actual website making dev easier

### DIFF
--- a/app/_config/toolbar.yml
+++ b/app/_config/toolbar.yml
@@ -13,7 +13,7 @@ Only:
   environment: dev
 ---
 GlobalNav:
-  hostname: '//ssorg.dev/'
+  hostname: '//www.silverstripe.org/'
   css_path: '/themes/ssv3/css/toolbar.min.css'
   use_localhost: false
 ---


### PR DESCRIPTION
We only need to alter this when we are testing new local changes to the toolbar.