### PR TITLE
API Simplify branches for userdocs to major versions only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+_ss_environment.php
 /src/
 .DS_Store
 .idea/

--- a/.htaccess
+++ b/.htaccess
@@ -31,8 +31,8 @@ ErrorDocument 500 /assets/error-500.html
 	SetEnv HTTP_MOD_REWRITE On
 	RewriteEngine On
 
-    RewriteCond %{HTTP_HOST} ^userhelp.silverstripe.com$ [NC]
-    RewriteRule ^(.*)$ https://userhelp.silverstripe.org/$1 [L,R=301]
+	RewriteCond %{HTTP_HOST} ^userhelp.silverstripe.com$ [NC]
+	RewriteRule ^(.*)$ https://userhelp.silverstripe.org/$1 [L,R=301]
 
 	RewriteCond %{REQUEST_URI} ^(.*)$
 	RewriteCond %{REQUEST_FILENAME} !-f
@@ -42,24 +42,27 @@ ErrorDocument 500 /assets/error-500.html
 	RewriteRule ^DocumentationSearchForm/?(.*)$ /dev/docs/DocumentationSearchForm/$1 [R=301,L]
 
 	#Strip .md extension
-    RewriteRule ^(.*)\.md/?$ /$1 [R=301,L]
+	RewriteRule ^(.*)\.md/?$ /$1 [R=301,L]
 
 	RewriteRule ^en/([0-9]\.[0-9])/basic-overview/?$ /en/$1 [R=301,L]
-    RewriteRule ^en/([0-9]\.[0-9])/for-website-administrators/?$ /en/$1/managing_your_website [R=301,L]
-    RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/?$ /en/$1/creating_pages_and_content [R=301,L]
-    RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/creating-and-editing-content/?$ /en/$1/creating_pages_and_content [R=301,L]
-    RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/forms/?$ /en/$1/optional_features/forms [R=301,L]
-    RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/forums/?$ /en/$1/optional_features/forums [R=301,L]
-    RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/managing-your-site/?$ /en/$1/creating_pages_and_content/pages [R=301,L]
-    RewriteRule ^en(/[0-9]\.[0-9])?/for-website-content-editors/web-content-best-practises/?$ /en$1/creating_pages_and_content/web_content_best_practises [R=301,L]
-    RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/working-with-images-and-documents/?$ /en/$1/creating_pages_and_content/working_with_images_and_documents [R=301,L]
-    RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/working-with-multiple-sites/?$ /en/$1/optional_features/working_with_multiple_sites [R=301,L]
-    RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/working-with-translations/?$ /en/$1/optional_features/working_with_translations [R=301,L]
-    RewriteRule ^en/([0-9]\.[0-9])/introduction-and-logging-in/?$ /en/$1/managing_your_website/logging_in [R=301,L]
-    RewriteRule ^en/([0-9]\.[0-9])/for-website-administrators/setting-up-advancedworkflow/?$ /en/$1/optional_features/setting_up_advancedworkflow [R=301,L]
-    RewriteRule ^en/([0-9]\.[0-9])/for-website-administrators/changing-and-managing-users/?$ /en/$1/managing_your_website/changing_and_managing_users [R=301,L]
-    RewriteRule ^en/([0-9]\.[0-9])/for-website-administrators/managing-roles-and-permissions/?$ /en/$1/managing_your_website/managing_roles_and_permissions [R=301,L]
-    RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/blogs/?$ /en/$1/optional_features/blogs [R=301,L]
+	RewriteRule ^en/([0-9]\.[0-9])/for-website-administrators/?$ /en/$1/managing_your_website [R=301,L]
+	RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/?$ /en/$1/creating_pages_and_content [R=301,L]
+	RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/creating-and-editing-content/?$ /en/$1/creating_pages_and_content [R=301,L]
+	RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/forms/?$ /en/$1/optional_features/forms [R=301,L]
+	RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/forums/?$ /en/$1/optional_features/forums [R=301,L]
+	RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/managing-your-site/?$ /en/$1/creating_pages_and_content/pages [R=301,L]
+	RewriteRule ^en(/[0-9]\.[0-9])?/for-website-content-editors/web-content-best-practises/?$ /en$1/creating_pages_and_content/web_content_best_practises [R=301,L]
+	RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/working-with-images-and-documents/?$ /en/$1/creating_pages_and_content/working_with_images_and_documents [R=301,L]
+	RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/working-with-multiple-sites/?$ /en/$1/optional_features/working_with_multiple_sites [R=301,L]
+	RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/working-with-translations/?$ /en/$1/optional_features/working_with_translations [R=301,L]
+	RewriteRule ^en/([0-9]\.[0-9])/introduction-and-logging-in/?$ /en/$1/managing_your_website/logging_in [R=301,L]
+	RewriteRule ^en/([0-9]\.[0-9])/for-website-administrators/setting-up-advancedworkflow/?$ /en/$1/optional_features/setting_up_advancedworkflow [R=301,L]
+	RewriteRule ^en/([0-9]\.[0-9])/for-website-administrators/changing-and-managing-users/?$ /en/$1/managing_your_website/changing_and_managing_users [R=301,L]
+	RewriteRule ^en/([0-9]\.[0-9])/for-website-administrators/managing-roles-and-permissions/?$ /en/$1/managing_your_website/managing_roles_and_permissions [R=301,L]
+	RewriteRule ^en/([0-9]\.[0-9])/for-website-content-editors/blogs/?$ /en/$1/optional_features/blogs [R=301,L]
+
+	# Redirect any version > 3.4 to 3 branch
+	RewriteRule ^en/3\.[5-9]/(.*)?$ /en/3/$1 [R=301,L]
 
 	# Legacy rewrites
 	RewriteCond %{REQUEST_FILENAME} !-f
@@ -81,11 +84,11 @@ ErrorDocument 500 /assets/error-500.html
 FileETag INode MTime
 
 <IfModule mod_expires.c>
-        ExpiresActive on
-        ExpiresByType image/* "access plus 7 days"
-        ExpiresByType text/css "access plus 7 days"
-        ExpiresByType application/x-javascript "access plus 7 days"
-        ExpiresByType application/javascript "access plus 7 days"
+	ExpiresActive on
+	ExpiresByType image/* "access plus 7 days"
+	ExpiresByType text/css "access plus 7 days"
+	ExpiresByType application/x-javascript "access plus 7 days"
+	ExpiresByType application/javascript "access plus 7 days"
 </IfModule>
 
 <IfModule mod_deflate.c>

--- a/README.md
+++ b/README.md
@@ -44,12 +44,13 @@ DocumentationManifest:
     -
       Path: "assets/src/userhelp_3.2/docs/"
       Title: "User Help"
+      VersionTitle: "3.x"
       Version: "3.2"
       Stable: true
       DefaultEntity: true
 ```
 
-Set `Stable: true` on the set of documentation relating the current stable version of SilverStripe CMS.
+Set `Stable: true` on the set of documentation relating the current stable major version of SilverStripe CMS. Set `Archived: true` for all other versions than the current major version.
 
 
 ## Contribution
@@ -59,7 +60,7 @@ theme, submit a pull request on GitHub. Any approved pull requests will make
 their way onto the userhelp.silverstripe.org site in the next release.
 
 The content for userhelp.silverstripe.org is stored in a separate repository:
-[https://github.com/silverstripe/silverstripe-userhelp-content](https://github.com/silverstripe/silverstripe-userhelp-content). 
+[silverstripe/silverstripe-userhelp-content](https://github.com/silverstripe/silverstripe-userhelp-content). 
 If you wish to edit the documentation content, submit a pull request to that Github project. Updates 
 to the content are synced regularly with userhelp.silverstripe.org via the cron job `UpdateDocsCronTask`.
 
@@ -67,9 +68,11 @@ to the content are synced regularly with userhelp.silverstripe.org via the cron 
 
 The cron job `UpdateDocsCronTask` includes tasks that fetch the latest documentation for each module from git and rebuilds the search indexes.
 
-	public function getSchedule() {
-    return "0 8 * * *"; // runs process() function every day at 8AM
-  }
+```php
+public function getSchedule()
+{
+    return '0 8 * * *'; // runs process() function every day at 8AM
+}
 
 ## Deployment
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ public function getSchedule()
 {
     return '0 8 * * *'; // runs process() function every day at 8AM
 }
+```
 
 ## Deployment
 

--- a/app/_config/docsviewer.yml
+++ b/app/_config/docsviewer.yml
@@ -12,32 +12,37 @@ DocumentationManifest:
     -
       Path: "assets/src/userhelp_3.5/docs/"
       Title: "User Help"
-      Version: "3.5"
+      VersionTitle: "3.x"
+      Version: "3"
       Stable: true
       DefaultEntity: true
     -
       Path: "assets/src/userhelp_3.4/docs/"
       Title: "User Help"
+      VersionTitle: "3.4"
       Version: "3.4"
-      DefaultEntity: true
+      Archived: true
     -
       Path: "assets/src/userhelp_3.3/docs/"
       Title: "User Help"
+      VersionTitle: "3.3"
       Version: "3.3"
-      DefaultEntity: true
+      Archived: true
     -
       Path: "assets/src/userhelp_3.2/docs/"
       Title: "User Help"
+      VersionTitle: "3.2"
       Version: "3.2"
-      DefaultEntity: true
+      Archived: true
     -
       Path: "assets/src/userhelp_3.1/docs/"
       Title: "User Help"
+      VersionTitle: "3.1"
       Version: "3.1"
-      DefaultEntity: true
+      Archived: true
     -
       Path: "assets/src/userhelp_3.0/docs/"
+      VersionTitle: "3.0"
       Title: "User Help"
       Version: "3.0"
-      DefaultEntity: true
-      
+      Archived: true

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "silverstripe/docsviewer": "dev-master",
+        "silverstripe/docsviewer": "^2.0@beta",
         "silverstripe/framework": "^3.2",
         "silverstripe/toolbar": "^4.2",
         "silverstripe/dynamodb": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,21 +4,21 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "4827e142bde07a1d280df298c5bed25a",
-    "content-hash": "9a9db95d02b870d9da2c9908350c05d2",
+    "hash": "246f4c43fe1e3d4a0d08d83367b40275",
+    "content-hash": "5b5a4919f48d96f573fcbcb1d37141eb",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
-            "version": "2.8.27",
+            "version": "2.8.31",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "c1605360b6624958a5397601ad5543cd45fcf8f7"
+                "reference": "64fa4b07f056e338a5f0f29eece75babaa83af68"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/c1605360b6624958a5397601ad5543cd45fcf8f7",
-                "reference": "c1605360b6624958a5397601ad5543cd45fcf8f7",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/64fa4b07f056e338a5f0f29eece75babaa83af68",
+                "reference": "64fa4b07f056e338a5f0f29eece75babaa83af68",
                 "shasum": ""
             },
             "require": {
@@ -68,20 +68,20 @@
                 "s3",
                 "sdk"
             ],
-            "time": "2016-01-30 00:53:32"
+            "time": "2016-07-25 18:03:20"
         },
         {
             "name": "composer/installers",
-            "version": "v1.0.23",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "6213d900e92647831f7a406d5c530ea1f3d4360e"
+                "reference": "d78064c68299743e0161004f2de3a0204e33b804"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/6213d900e92647831f7a406d5c530ea1f3d4360e",
-                "reference": "6213d900e92647831f7a406d5c530ea1f3d4360e",
+                "url": "https://api.github.com/repos/composer/installers/zipball/d78064c68299743e0161004f2de3a0204e33b804",
+                "reference": "d78064c68299743e0161004f2de3a0204e33b804",
                 "shasum": ""
             },
             "require": {
@@ -103,8 +103,8 @@
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Composer\\Installers\\": "src/"
+                "psr-4": {
+                    "Composer\\Installers\\": "src/Composer/Installers"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -119,28 +119,35 @@
                 }
             ],
             "description": "A multi-framework Composer library installer",
-            "homepage": "http://composer.github.com/installers/",
+            "homepage": "https://composer.github.io/installers/",
             "keywords": [
                 "Craft",
                 "Dolibarr",
                 "Hurad",
+                "ImageCMS",
                 "MODX Evo",
+                "Mautic",
                 "OXID",
+                "Plentymarkets",
+                "RadPHP",
                 "SMF",
                 "Thelia",
                 "WolfCMS",
                 "agl",
                 "aimeos",
                 "annotatecms",
+                "attogram",
                 "bitrix",
                 "cakephp",
                 "chef",
+                "cockpit",
                 "codeigniter",
                 "concrete5",
                 "croogo",
                 "dokuwiki",
                 "drupal",
                 "elgg",
+                "expressionengine",
                 "fuelphp",
                 "grav",
                 "installer",
@@ -157,29 +164,31 @@
                 "piwik",
                 "ppi",
                 "puppet",
+                "reindex",
                 "roundcube",
                 "shopware",
                 "silverstripe",
                 "symfony",
                 "typo3",
                 "wordpress",
+                "yawik",
                 "zend",
                 "zikula"
             ],
-            "time": "2016-01-27 12:54:22"
+            "time": "2016-08-13 20:53:52"
         },
         {
             "name": "doctrine/cache",
-            "version": "v1.6.0",
+            "version": "v1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/cache.git",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6"
+                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/cache/zipball/f8af318d14bdb0eff0336795b428b547bd39ccb6",
-                "reference": "f8af318d14bdb0eff0336795b428b547bd39ccb6",
+                "url": "https://api.github.com/repos/doctrine/cache/zipball/b6f544a20f4807e81f7044d31e679ccbb1866dc3",
+                "reference": "b6f544a20f4807e81f7044d31e679ccbb1866dc3",
                 "shasum": ""
             },
             "require": {
@@ -236,7 +245,7 @@
                 "cache",
                 "caching"
             ],
-            "time": "2015-12-31 16:37:02"
+            "time": "2016-10-29 11:16:17"
         },
         {
             "name": "erusev/parsedown",
@@ -458,23 +467,23 @@
         },
         {
             "name": "mtdowling/cron-expression",
-            "version": "v1.0.4",
+            "version": "v1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mtdowling/cron-expression.git",
-                "reference": "fd92e883195e5dfa77720b1868cf084b08be4412"
+                "reference": "c9ee7886f5a12902b225a1a12f36bb45f9ab89e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mtdowling/cron-expression/zipball/fd92e883195e5dfa77720b1868cf084b08be4412",
-                "reference": "fd92e883195e5dfa77720b1868cf084b08be4412",
+                "url": "https://api.github.com/repos/mtdowling/cron-expression/zipball/c9ee7886f5a12902b225a1a12f36bb45f9ab89e5",
+                "reference": "c9ee7886f5a12902b225a1a12f36bb45f9ab89e5",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3.2"
             },
             "require-dev": {
-                "phpunit/phpunit": "4.*"
+                "phpunit/phpunit": "~4.0|~5.0"
             },
             "type": "library",
             "autoload": {
@@ -498,35 +507,30 @@
                 "cron",
                 "schedule"
             ],
-            "time": "2015-01-11 23:07:46"
+            "time": "2016-01-26 21:23:30"
         },
         {
             "name": "silverstripe/crontask",
-            "version": "v1.1.0",
+            "version": "1.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-crontask.git",
-                "reference": "0db152c8edf448e3ed9797d60e181800ac67ed75"
+                "reference": "ef1992904075604b76a40cc286c0f448064ddc20"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-crontask/zipball/0db152c8edf448e3ed9797d60e181800ac67ed75",
-                "reference": "0db152c8edf448e3ed9797d60e181800ac67ed75",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-crontask/zipball/ef1992904075604b76a40cc286c0f448064ddc20",
+                "reference": "ef1992904075604b76a40cc286c0f448064ddc20",
                 "shasum": ""
             },
             "require": {
-                "mtdowling/cron-expression": "1.0.*",
+                "mtdowling/cron-expression": "~1.0",
                 "silverstripe/framework": "~3.1"
             },
             "require-dev": {
                 "phpunit/phpunit": "~3.7@stable"
             },
             "type": "silverstripe-module",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1.x-dev"
-                }
-            },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
@@ -546,20 +550,20 @@
                 "cron",
                 "silverstripe"
             ],
-            "time": "2014-11-20 01:20:17"
+            "time": "2016-09-13 10:39:18"
         },
         {
             "name": "silverstripe/docsviewer",
-            "version": "dev-master",
+            "version": "2.0.0-beta4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-docsviewer.git",
-                "reference": "9d7a1f621049980167a5a3ba4e7b418a62ee55ee"
+                "reference": "40d70a0b32f1ea63594238ab25aba9d9397416b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-docsviewer/zipball/9d7a1f621049980167a5a3ba4e7b418a62ee55ee",
-                "reference": "9d7a1f621049980167a5a3ba4e7b418a62ee55ee",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-docsviewer/zipball/40d70a0b32f1ea63594238ab25aba9d9397416b7",
+                "reference": "40d70a0b32f1ea63594238ab25aba9d9397416b7",
                 "shasum": ""
             },
             "require": {
@@ -587,20 +591,20 @@
                 "documentation",
                 "silverstripe"
             ],
-            "time": "2016-11-07 13:31:41"
+            "time": "2016-12-04 21:22:45"
         },
         {
             "name": "silverstripe/dynamodb",
-            "version": "1.1.0",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-dynamodb.git",
-                "reference": "1336a57cbb5b8a19abd2b9f67099db9a20aaf8c4"
+                "reference": "2d1eefeaf2efea7d5daaead587dc6966630633c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-dynamodb/zipball/1336a57cbb5b8a19abd2b9f67099db9a20aaf8c4",
-                "reference": "1336a57cbb5b8a19abd2b9f67099db9a20aaf8c4",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-dynamodb/zipball/2d1eefeaf2efea7d5daaead587dc6966630633c0",
+                "reference": "2d1eefeaf2efea7d5daaead587dc6966630633c0",
                 "shasum": ""
             },
             "require": {
@@ -628,20 +632,20 @@
                 "dynamodb",
                 "silverstripe"
             ],
-            "time": "2015-11-23 20:48:17"
+            "time": "2016-03-03 21:34:17"
         },
         {
             "name": "silverstripe/framework",
-            "version": "3.3.1",
+            "version": "3.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/silverstripe/silverstripe-framework.git",
-                "reference": "fb582332010873c1ec03f5644263667f615b1f98"
+                "reference": "179996b5f9ccbaab8882cafbf16c389623521b72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/silverstripe/silverstripe-framework/zipball/fb582332010873c1ec03f5644263667f615b1f98",
-                "reference": "fb582332010873c1ec03f5644263667f615b1f98",
+                "url": "https://api.github.com/repos/silverstripe/silverstripe-framework/zipball/179996b5f9ccbaab8882cafbf16c389623521b72",
+                "reference": "179996b5f9ccbaab8882cafbf16c389623521b72",
                 "shasum": ""
             },
             "require": {
@@ -654,7 +658,7 @@
             "type": "silverstripe-module",
             "extra": {
                 "branch-alias": {
-                    "3.x-dev": "3.3.x-dev"
+                    "3.x-dev": "3.5.x-dev"
                 }
             },
             "autoload": {
@@ -682,7 +686,7 @@
                 "framework",
                 "silverstripe"
             ],
-            "time": "2016-02-29 02:23:25"
+            "time": "2016-11-28 12:35:19"
         },
         {
             "name": "silverstripe/toolbar",
@@ -730,16 +734,16 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v2.8.3",
+            "version": "v2.8.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "78c468665c9568c3faaa9c416a7134308f2d85c3"
+                "reference": "25c576abd4e0f212e678fe8b2bd9a9a98c7ea934"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/78c468665c9568c3faaa9c416a7134308f2d85c3",
-                "reference": "78c468665c9568c3faaa9c416a7134308f2d85c3",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/25c576abd4e0f212e678fe8b2bd9a9a98c7ea934",
+                "reference": "25c576abd4e0f212e678fe8b2bd9a9a98c7ea934",
                 "shasum": ""
             },
             "require": {
@@ -786,20 +790,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-01-27 05:14:19"
+            "time": "2016-10-13 01:43:15"
         },
         {
             "name": "unclecheese/display-logic",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/unclecheese/silverstripe-display-logic.git",
-                "reference": "43a2213c4748c3f56fc91842ab3a4a3b22caacf0"
+                "reference": "7165e51f90f2de793d313bf015f4df17642bc060"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/unclecheese/silverstripe-display-logic/zipball/43a2213c4748c3f56fc91842ab3a4a3b22caacf0",
-                "reference": "43a2213c4748c3f56fc91842ab3a4a3b22caacf0",
+                "url": "https://api.github.com/repos/unclecheese/silverstripe-display-logic/zipball/7165e51f90f2de793d313bf015f4df17642bc060",
+                "reference": "7165e51f90f2de793d313bf015f4df17642bc060",
                 "shasum": ""
             },
             "require": {
@@ -830,14 +834,14 @@
                 "logic",
                 "silverstripe"
             ],
-            "time": "2015-12-14 22:02:51"
+            "time": "2016-06-21 00:24:32"
         }
     ],
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
-        "silverstripe/docsviewer": 20
+        "silverstripe/docsviewer": 10
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/themes/userhelp/templates/Includes/DocumentationVersions.ss
+++ b/themes/userhelp/templates/Includes/DocumentationVersions.ss
@@ -1,18 +1,24 @@
-<% if Versions %>
+<% if $Versions %>
 	<div class="versions">
 		<ul>
-			<% loop Versions.sort("Title DESC").limit(3) %>
-				<li><a href="$Link" class="$LinkingMode">$Title<% if $IsStable %> (latest CMS version)<% end_if %></a></li>
+			<% loop $Versions.sort("Title DESC") %>
+				<% if not $Archived %>
+					<li>
+						<a href="$Link" class="$LinkingMode">$Title<% if $IsStable %> (latest CMS version)<% end_if %></a>
+					</li>
+				<% end_if %>
 			<% end_loop %>
 		</ul>
 	</div>
 	<form id="VersionsArchive">
-			<select id="VersionSelect" onchange="location.href=VersionsArchive.VersionSelect.options[selectedIndex].value">
-				<option>Older CMS versions</option>
-				<% loop Versions.sort("Title DESC").limit(20, 3) %>
-     			<option value="$Link">$Title</option>
-     			<% end_loop %>
-				<option value="http://2.4.userhelp.silverstripe.org">2.4</option>
-			</select>
-		</form>
+		<select id="VersionSelect" onchange="location.href=VersionsArchive.VersionSelect.options[selectedIndex].value">
+			<option>Older CMS versions</option>
+			<% loop $Versions.sort("Title DESC").limit(20) %>
+				<% if $Archived %>
+					<option value="$Link">$Title</option>
+				<% end_if %>
+			<% end_loop %>
+			<option value="http://2.4.userhelp.silverstripe.org">2.4</option>
+		</select>
+	</form>
 <% end_if %>


### PR DESCRIPTION
This is not necessarily required, as the user docs content is versioned separately from the framework docs so we could retain old/archived/deleted branches if we want, but this could be a good move for continuity between the dev and user docs.

See:

- API: silverstripe/silverstripe-docsviewer#126
- Dev docs equivalent: silverstripe/doc.silverstripe.org#151

Again, the original dev docs issue at silverstripe/doc.silverstripe.org#146 will not affect the user docs content since it's stored in a different repository.

Screenshot of user docs changes:

![Example - major versions only](https://cloud.githubusercontent.com/assets/5170590/20872002/e6855686-baff-11e6-8a79-dc4f4ed9df09.png)

Yeah - looks a little odd without any 4.x user docs :)