### PR TITLE
Add 3.6 as new, current stable version

### DIFF
--- a/app/_config/docs-repositories.yml
+++ b/app/_config/docs-repositories.yml
@@ -9,6 +9,10 @@ RefreshMarkdownTask:
     -
       - silverstripe/silverstripe-userhelp-content
       - userhelp
+      - "3.6"
+    -
+      - silverstripe/silverstripe-userhelp-content
+      - userhelp
       - "3.5"
     -
       - silverstripe/silverstripe-userhelp-content

--- a/app/_config/docsviewer.yml
+++ b/app/_config/docsviewer.yml
@@ -9,16 +9,23 @@ DocumentationSearch:
 DocumentationManifest:
   automatic_registration: false
   register_entities:
+    # 4.0 doesn't have anything in it yet, uncomment when it has some content
+    # See: https://github.com/silverstripe/userhelp.silverstripe.org/pull/48
+    # -
+    #   Path: "assets/src/userhelp_master/docs/"
+    #   Title: "User Help"
+    #   Version: "4.0"
+    #   DefaultEntity: true
     -
-      Path: "assets/src/userhelp_master/docs/"
+      Path: "assets/src/userhelp_3.6/docs/"
       Title: "User Help"
-      Version: "4.0"
+      Version: "3.6"
+      Stable: true
       DefaultEntity: true
     -
       Path: "assets/src/userhelp_3.5/docs/"
       Title: "User Help"
       Version: "3.5"
-      Stable: true
       DefaultEntity: true
     -
       Path: "assets/src/userhelp_3.4/docs/"
@@ -45,4 +52,4 @@ DocumentationManifest:
       Title: "User Help"
       Version: "3.0"
       DefaultEntity: true
-      
+


### PR DESCRIPTION
Adds 3.6 as the new stable version.

Replaces #48 which moves towards major versions e.g. 4.x and 3.x, like docs.silverstripe.org does now. We don't have any userhelp content for it yet though.