### PR TITLE
Add silverstripe/dms userhelp to 3.6

### DIFF
--- a/app/_config/docs-repositories.yml
+++ b/app/_config/docs-repositories.yml
@@ -106,3 +106,7 @@ RefreshMarkdownTask:
       - silverstripe-labs/silverstripe-securityreport
       - securityreport
       - master
+    -
+      - silverstripe/silverstripe-dms
+      - dms
+      - master


### PR DESCRIPTION
Requires https://github.com/silverstripe/silverstripe-userhelp-content/pull/35