### PR TITLE
DOCS Add 3.5/w.6 userhelp content back

### DIFF
--- a/app/_config/docs-repositories.yml
+++ b/app/_config/docs-repositories.yml
@@ -9,7 +9,11 @@ RefreshMarkdownTask:
     -
       - silverstripe/silverstripe-userhelp-content
       - userhelp
-      - "3"
+      - "3.6"
+    -
+      - silverstripe/silverstripe-userhelp-content
+      - userhelp
+      - "3.5"
     -
       - silverstripe/silverstripe-userhelp-content
       - userhelp


### PR DESCRIPTION
Adds back minor versions temporarily until 4 docs are ready for prod, will be reverted in https://github.com/silverstripe/userhelp.silverstripe.org/pull/62