### PR TITLE
Add doc repo requirement for Document Converter

### DIFF
--- a/app/_config/docs-repositories.yml
+++ b/app/_config/docs-repositories.yml
@@ -158,3 +158,7 @@ RefreshMarkdownTask:
       - silverstripe/silverstripe-sharedraftcontent
       - silverstripe-sharedraftcontent
       - master
+    -
+      - silverstripe/silverstripe-documentconverter
+      - silverstripe-documentconverter
+      - master


### PR DESCRIPTION
Relies on https://github.com/silverstripe/silverstripe-userhelp-content/pull/124
Original issue: https://github.com/silverstripe/silverstripe-userhelp-content/issues/122