### PR TITLE
NEW Allow docs configuration to be keyed

### DIFF
--- a/app/code/RefreshMarkdownTask.php
+++ b/app/code/RefreshMarkdownTask.php
@@ -78,7 +78,13 @@ class RefreshMarkdownTask extends BuildTask
      */
     private function cloneRepository(array $repository)
     {
-        list($remote, $folder, $branch) = $repository;
+        if (isset($repository['remote'], $repository['folder'], $repository['branch'])) {
+            $remote = $repository['remote'];
+            $folder = $repository['folder'];
+            $branch = $repository['branch'];
+        } else {
+            list($remote, $folder, $branch) = $repository;
+        }
 
         $path = $this->getPath();
 


### PR DESCRIPTION
This should allow you to key the YAML so it's much easier to PR and you don't have to regain context every time.

So instead of 
```yaml
    -
      - silverstripe/silverstripe-sharedraftcontent
      - silverstripe-sharedraftcontent
      - master
```

It _can_ be:
```yaml
    -
      remote: silverstripe/silverstripe-sharedraftcontent
      folder: silverstripe-sharedraftcontent
      branch: master
```