### PR TITLE
FIX Remove 'documentation' label from link to create issue in documentation repo

### DIFF
--- a/themes/userhelp/templates/Includes/DocumentationFooter.ss
+++ b/themes/userhelp/templates/Includes/DocumentationFooter.ss
@@ -2,7 +2,7 @@
 	<p>
         Documentation powered by <a href="http://www.silverstripe.org">SilverStripe</a> (<a href="https://github.com/silverstripe/userhelp.silverstripe.org">code</a>).
         <a href="https://github.com/silverstripe/silverstripe-userhelp-content">Contribute documentation to userhelp.silverstripe.org</a>,
-        <a href="https://github.com/silverstripe/silverstripe-userhelp-content/issues/new?labels=documentation">raise a bug or enhancement ticket</a>.
+        <a href="https://github.com/silverstripe/silverstripe-userhelp-content/issues/new">raise a bug or enhancement ticket</a>.
     </p>
     <p>
         <a class="cc-license" rel="license" href="http://creativecommons.org/licenses/by/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by/4.0/88x31.png" /></a> This work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International License</a>.


### PR DESCRIPTION
It's a given that it will be documentation related, so we don't need to append that label automatically.